### PR TITLE
Improve API key sourcing and input validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ well‑formatted table in the console or written directly to a CSV file.
   improved performance.
 - **Progress indicator**: A terminal progress bar shows how many queries have
   completed.
+- **Script-friendly authentication**: Provide the API key via the
+  `ABUSEIPDB_API_KEY` environment variable or interactively when omitted.
+- **Input validation**: IPv4 and IPv6 addresses are validated before requests
+  are sent so malformed entries are skipped with a clear message.
 - **Filter by confidence**: Optionally exclude results with an
   `abuseConfidenceScore` less than `100` using the `-x/--exclude` flag.
 - **CSV output**: Save results to a CSV file instead of printing a table.


### PR DESCRIPTION
## Summary
- allow providing the AbuseIPDB API key via the ABUSEIPDB_API_KEY environment variable while retaining the interactive prompt fallback
- validate IPv4 and IPv6 inputs before issuing requests and surface clear skip messages for malformed entries
- refactor error handling into a helper to reduce duplication and document the new behaviour in the README

## Testing
- python -m compileall abuseipdb_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e4dc21e6c0833197cc05a2dc8acce0